### PR TITLE
call,put返回dispatch的返回值

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -21,22 +21,22 @@ export const getState = function (args) {
     }
 };
 
-export const call = function(type, ...args) {
-    if(getAction(type)) {
-        dispatch(getAction(type)(...args));
-    }else{
-        dispatch({
+export const call = function (type, ...args) {
+    if (getAction(type)) {
+        return dispatch(getAction(type)(...args));
+    } else {
+        return dispatch({
             type,
-            payload:{...args}
+            payload: {...args}
         });
     }
 };
 
-export const put = function({type,payload}) {
-    if(getAction(type)) {
-        dispatch(getAction(type)(payload || {}));
-    }else{
-        dispatch({
+export const put = function ({type, payload}) {
+    if (getAction(type)) {
+        return dispatch(getAction(type)(payload || {}));
+    } else {
+        return dispatch({
             type,
             payload
         });

--- a/src/redux/middleware.js
+++ b/src/redux/middleware.js
@@ -25,7 +25,7 @@ export default (debug) => ({dispatch, getState}) => next => action => {
         if (typeof action === 'function') {
             if (isPromise(action)) {
                 callStartReducer(dispatch, action);
-                action.then(
+                return action.then(
                     (result) => {
                         dispatch({
                             ...action,
@@ -53,7 +53,7 @@ export default (debug) => ({dispatch, getState}) => next => action => {
         let res = action.payload({dispatch, getState, put, call});
         if (isPromise(res)) {
             callStartReducer(dispatch, action);
-            res.then(
+            return res.then(
                 (result) => {
                     dispatch({
                         ...action,
@@ -72,14 +72,14 @@ export default (debug) => ({dispatch, getState}) => next => action => {
                 }
             );
         } else {
-            dispatch({
+            return dispatch({
                 ...action,
                 payload: res
             });
         }
     } else if (isPromise(action.payload)) {
         callStartReducer(dispatch, action);
-        action.payload.then(
+        return action.payload.then(
             (result) => {
                 dispatch({
                     ...action,
@@ -98,6 +98,6 @@ export default (debug) => ({dispatch, getState}) => next => action => {
             }
         );
     } else {
-        next(action);
+        return next(action);
     }
 };


### PR DESCRIPTION
支持这种调用方式
``` javascript
call(某异步action).then(业务方自己的处理)
```
做的更改：
1. call,put返回dispatch的返回值。
2. middleware中与redux-thunk处理一致，返回dispatch的返回值。